### PR TITLE
兼容更多筆畫輸入風格

### DIFF
--- a/stroke.schema.yaml
+++ b/stroke.schema.yaml
@@ -55,12 +55,12 @@ menu:
 translator:
   dictionary: stroke
   preedit_format:
-  # - xlit/hspnz/㇐㇑㇒㇏㇠/ # 中日韓筆畫
-    - xlit/hspnz/⼀⼁⼃⼂⼄/ # 康熙部首
+#   - xlit/hspnz/㇐㇑㇒㇏㇠/   # 中日韓筆畫（橫豎撇捺折）
+    - xlit/hspnz/⼀⼁⼃⼂⼄/   # 康熙部首（橫豎撇點折）
   comment_format:
     - xform/~//
-  # - xlit/hspnz/㇐㇑㇒㇏㇠/ # 中日韓筆畫
-    - xlit/hspnz/⼀⼁⼃⼂⼄/ # 康熙部首
+#   - xlit/hspnz/㇐㇑㇒㇏㇠/   # 中日韓筆畫（橫豎撇捺折）
+    - xlit/hspnz/⼀⼁⼃⼂⼄/   # 康熙部首（橫豎撇點折）
 
 abc_segmentor:
   extra_tags:
@@ -76,14 +76,17 @@ reverse_lookup:
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
   comment_format:
-  # - xlit/hspnz/㇐㇑㇒㇏㇠/ # 中日韓筆畫
-    - xlit/hspnz/⼀⼁⼃⼂⼄/ # 康熙部首
+#   - xlit/hspnz/㇐㇑㇒㇏㇠/   # 中日韓筆畫（橫豎撇捺折）
+    - xlit/hspnz/⼀⼁⼃⼂⼄/   # 康熙部首（橫豎撇點折）
 
 punctuator:
   import_preset: default
 
 key_binder:
   import_preset: default
+  bindings:
+    - { when: always, accept: "d", send: "n" }  # 捺屬點部
+    - { when: always, accept: "t", send: "h" }  # 提屬橫部
 
 recognizer:
   import_preset: default

--- a/stroke.schema.yaml
+++ b/stroke.schema.yaml
@@ -55,10 +55,12 @@ menu:
 translator:
   dictionary: stroke
   preedit_format:
-    - xlit/hspnz/一丨丿丶乙/
+  # - xlit/hspnz/㇐㇑㇒㇏㇠/ # 中日韓筆畫
+    - xlit/hspnz/⼀⼁⼃⼂⼄/ # 康熙部首
   comment_format:
     - xform/~//
-    - xlit/hspnz/一丨丿丶乙/
+  # - xlit/hspnz/㇐㇑㇒㇏㇠/ # 中日韓筆畫
+    - xlit/hspnz/⼀⼁⼃⼂⼄/ # 康熙部首
 
 abc_segmentor:
   extra_tags:
@@ -74,7 +76,8 @@ reverse_lookup:
     - xform/([nl])ue/$1üe/
     - xform/([jqxy])v/$1u/
   comment_format:
-    - xlit/hspnz/一丨丿丶乙/
+  # - xlit/hspnz/㇐㇑㇒㇏㇠/ # 中日韓筆畫
+    - xlit/hspnz/⼀⼁⼃⼂⼄/ # 康熙部首
 
 punctuator:
   import_preset: default

--- a/stroke.schema.yaml
+++ b/stroke.schema.yaml
@@ -85,8 +85,27 @@ punctuator:
 key_binder:
   import_preset: default
   bindings:
-    - { when: always, accept: "d", send: "n" }  # 捺屬點部
-    - { when: always, accept: "t", send: "h" }  # 提屬橫部
+    # 兼容其他筆畫名稱（捺屬點部、提屬橫部）
+    - { when: always, accept: "d", send: "n" }
+    - { when: always, accept: "t", send: "h" }
+    # 兼容Mac筆畫輸入法按鍵：🅹⼀, 🅺⼁, 🅻⼃, 🆄⼂, 🅸⺂
+    - { when: always, accept: "j", send: "h" }
+    - { when: always, accept: "k", send: "s" }
+    - { when: always, accept: "l", send: "p" }
+    - { when: always, accept: "u", send: "n" }
+    - { when: always, accept: "i", send: "z" }
+    # 兼容Mac筆畫輸入法小鍵盤按鍵：1︎⃣⼀, 2︎⃣⼁, 3︎⃣⼃, 4︎⃣⼂, 5︎⃣⺂
+    - { when: always, accept: "KP_1", send: "h" }
+    - { when: always, accept: "KP_2", send: "s" }
+    - { when: always, accept: "KP_3", send: "p" }
+    - { when: always, accept: "KP_4", send: "n" }
+    - { when: always, accept: "KP_5", send: "z" }
+    # 禁用小鍵盤其他數字按鍵，以防誤觸
+    - { when: has_menu, accept: "KP_6", send: Select }
+    - { when: has_menu, accept: "KP_7", send: Select }
+    - { when: has_menu, accept: "KP_8", send: Select }
+    - { when: has_menu, accept: "KP_9", send: Select }
+    - { when: has_menu, accept: "KP_0", send: Select }
 
 recognizer:
   import_preset: default


### PR DESCRIPTION
- 筆畫改用Unicode康熙部首或中日韓筆畫的字符，以避免與漢字混淆
- 兼容其他筆畫名稱（捺屬點部、提屬橫部）
Resolves #2 
- 兼容Mac筆畫輸入法按鍵：🅹⼀, 🅺⼁, 🅻⼃, 🆄⼂, 🅸⺂, 1︎⃣⼀, 2︎⃣⼁, 3︎⃣⼃, 4︎⃣⼂, 5︎⃣⺂