### PR TITLE
remove wrong and duplicated 㟡

### DIFF
--- a/stroke.dict.yaml
+++ b/stroke.dict.yaml
@@ -1014,7 +1014,6 @@ max_phrase_length: 1         # 不生成詞彙
 㟞	szshznphznp
 㟟	szshsshpnzz
 㟠	szssznphszs
-㟡	szs
 㟢	szshpnhszhz
 㟣	szshspnpnzn
 㟤	szszhhznnpn


### PR DESCRIPTION
Fixes #11 
Correct 㟡 was already at line 75424 (and will be at line 75423 after this PR).